### PR TITLE
Some tweaks for nixOS/nixpkgs#336735

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14382,6 +14382,13 @@
     githubId = 818502;
     name = "Nathan Yong";
   };
+  natsukagami = {
+    email = "natsukagami@gmail.com";
+    github = "natsukagami";
+    githubId = 9061737;
+    name = "Natsu Kagami";
+    keys = [ { fingerprint = "5581 26DC 886F E14D 501D  B0F2 D6AD 7B57 A992 460C"; } ];
+  };
   natsukium = {
     email = "nixpkgs@natsukium.com";
     github = "natsukium";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5394,6 +5394,12 @@
     name = "Misha Gusarov";
     keys = [ { fingerprint = "A8DF 1326 9E5D 9A38 E57C  FAC2 9D20 F650 3E33 8888"; } ];
   };
+  dottybot = {
+    name = "Scala Organization (dottybot)";
+    email = "dottybot@groupes.epfl.ch";
+    github = "dottybot";
+    githubId = 12519979;
+  };
   dpaetzel = {
     email = "david.paetzel@posteo.de";
     github = "dpaetzel";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7988,6 +7988,12 @@
     githubId = 1742172;
     name = "Hamish Hutchings";
   };
+  hamzaremmal = {
+    email = "hamza.remmal@epfl.ch";
+    github = "hamzaremmal";
+    githubId = 56235032;
+    name = "Hamza Remmal";
+  };
   hanemile = {
     email = "mail@emile.space";
     github = "HanEmile";

--- a/pkgs/development/compilers/scala/bare.nix
+++ b/pkgs/development/compilers/scala/bare.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "scala-bare";
 
   src = fetchurl {
-    url = "https://github.com/lampepfl/dotty/releases/download/${finalAttrs.version}/scala3-${finalAttrs.version}.tar.gz";
+    url = "https://github.com/scala/scala3/releases/download/${finalAttrs.version}/scala3-${finalAttrs.version}.tar.gz";
     hash = "sha256-61lAETEvqkEqr5pbDltFkh+Qvp+EnCDilXN9X67NFNE=";
   };
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "The Scala 3 compiler, also known as Dotty";
-    homepage = "http://dotty.epfl.ch/";
+    homepage = "https://scala-lang.org/";
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [

--- a/pkgs/development/compilers/scala/bare.nix
+++ b/pkgs/development/compilers/scala/bare.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
       karolchmist
       virusdave
       kashw2
+      natsukagami
+      hamzaremmal
+      dottybot
     ];
   };
 })

--- a/pkgs/development/compilers/scala/bare.nix
+++ b/pkgs/development/compilers/scala/bare.nix
@@ -37,13 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    description = "Research platform for new language concepts and compiler technologies for Scala";
-    longDescription = ''
-      Dotty is a platform to try out new language concepts and compiler technologies for Scala.
-      The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),
-      and try to boil down Scala’s types into a smaller set of more fundamental constructs.
-      The theory behind these constructs is researched in DOT, a calculus for dependent object types.
-    '';
+    description = "The Scala 3 compiler, also known as Dotty";
     homepage = "http://dotty.epfl.ch/";
     license = licenses.bsd3;
     platforms = platforms.all;

--- a/pkgs/development/compilers/scala/bare.nix
+++ b/pkgs/development/compilers/scala/bare.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "The Scala 3 compiler, also known as Dotty";
     homepage = "https://scala-lang.org/";
-    license = licenses.bsd3;
+    license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [
       karolchmist


### PR DESCRIPTION
- Add me (@natsukagami) and Hamza (@hamzaremmal) from Scala organization and the semi-automated Scala organization account (@dottybot) as the maintainers of the package.
- Simplify the Scala package description, since we are no longer an experimental platform to develop Scala, we are the official Scala compiler now.
- Change links to point to the official Scala website and the new repo 